### PR TITLE
20251214_SupabaseのDiaryDBに登録実装

### DIFF
--- a/lib/features/diary/model/diary.dart
+++ b/lib/features/diary/model/diary.dart
@@ -1,0 +1,23 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'diary.freezed.dart';
+part 'diary.g.dart';
+
+@freezed
+abstract class Diary with _$Diary {
+
+  // プロパティ指定
+  const factory Diary({
+    @JsonKey(name: 'post_id', includeToJson: false)
+    String? postId,
+    required DateTime date,
+    required String title,
+    required String description,
+    @JsonKey(name: 'user_id')
+    required String userId,
+    @JsonKey(name: 'updated_date', includeToJson: false)
+    DateTime? updatedDate,
+  }) = _Diary;
+
+  factory Diary.fromJson(Map<String, dynamic> json) => _$DiaryFromJson(json);
+}

--- a/lib/features/diary/model/diary.freezed.dart
+++ b/lib/features/diary/model/diary.freezed.dart
@@ -1,0 +1,292 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'diary.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Diary {
+
+@JsonKey(name: 'post_id', includeToJson: false) String? get postId; DateTime get date; String get title; String get description;@JsonKey(name: 'user_id') String get userId;@JsonKey(name: 'updated_date', includeToJson: false) DateTime? get updatedDate;
+/// Create a copy of Diary
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$DiaryCopyWith<Diary> get copyWith => _$DiaryCopyWithImpl<Diary>(this as Diary, _$identity);
+
+  /// Serializes this Diary to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Diary&&(identical(other.postId, postId) || other.postId == postId)&&(identical(other.date, date) || other.date == date)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.updatedDate, updatedDate) || other.updatedDate == updatedDate));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,postId,date,title,description,userId,updatedDate);
+
+@override
+String toString() {
+  return 'Diary(postId: $postId, date: $date, title: $title, description: $description, userId: $userId, updatedDate: $updatedDate)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $DiaryCopyWith<$Res>  {
+  factory $DiaryCopyWith(Diary value, $Res Function(Diary) _then) = _$DiaryCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'post_id', includeToJson: false) String? postId, DateTime date, String title, String description,@JsonKey(name: 'user_id') String userId,@JsonKey(name: 'updated_date', includeToJson: false) DateTime? updatedDate
+});
+
+
+
+
+}
+/// @nodoc
+class _$DiaryCopyWithImpl<$Res>
+    implements $DiaryCopyWith<$Res> {
+  _$DiaryCopyWithImpl(this._self, this._then);
+
+  final Diary _self;
+  final $Res Function(Diary) _then;
+
+/// Create a copy of Diary
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? postId = freezed,Object? date = null,Object? title = null,Object? description = null,Object? userId = null,Object? updatedDate = freezed,}) {
+  return _then(_self.copyWith(
+postId: freezed == postId ? _self.postId : postId // ignore: cast_nullable_to_non_nullable
+as String?,date: null == date ? _self.date : date // ignore: cast_nullable_to_non_nullable
+as DateTime,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,description: null == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,updatedDate: freezed == updatedDate ? _self.updatedDate : updatedDate // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [Diary].
+extension DiaryPatterns on Diary {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Diary value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Diary() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Diary value)  $default,){
+final _that = this;
+switch (_that) {
+case _Diary():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Diary value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Diary() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'post_id', includeToJson: false)  String? postId,  DateTime date,  String title,  String description, @JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'updated_date', includeToJson: false)  DateTime? updatedDate)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Diary() when $default != null:
+return $default(_that.postId,_that.date,_that.title,_that.description,_that.userId,_that.updatedDate);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'post_id', includeToJson: false)  String? postId,  DateTime date,  String title,  String description, @JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'updated_date', includeToJson: false)  DateTime? updatedDate)  $default,) {final _that = this;
+switch (_that) {
+case _Diary():
+return $default(_that.postId,_that.date,_that.title,_that.description,_that.userId,_that.updatedDate);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'post_id', includeToJson: false)  String? postId,  DateTime date,  String title,  String description, @JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'updated_date', includeToJson: false)  DateTime? updatedDate)?  $default,) {final _that = this;
+switch (_that) {
+case _Diary() when $default != null:
+return $default(_that.postId,_that.date,_that.title,_that.description,_that.userId,_that.updatedDate);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _Diary implements Diary {
+  const _Diary({@JsonKey(name: 'post_id', includeToJson: false) this.postId, required this.date, required this.title, required this.description, @JsonKey(name: 'user_id') required this.userId, @JsonKey(name: 'updated_date', includeToJson: false) this.updatedDate});
+  factory _Diary.fromJson(Map<String, dynamic> json) => _$DiaryFromJson(json);
+
+@override@JsonKey(name: 'post_id', includeToJson: false) final  String? postId;
+@override final  DateTime date;
+@override final  String title;
+@override final  String description;
+@override@JsonKey(name: 'user_id') final  String userId;
+@override@JsonKey(name: 'updated_date', includeToJson: false) final  DateTime? updatedDate;
+
+/// Create a copy of Diary
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$DiaryCopyWith<_Diary> get copyWith => __$DiaryCopyWithImpl<_Diary>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$DiaryToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Diary&&(identical(other.postId, postId) || other.postId == postId)&&(identical(other.date, date) || other.date == date)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.updatedDate, updatedDate) || other.updatedDate == updatedDate));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,postId,date,title,description,userId,updatedDate);
+
+@override
+String toString() {
+  return 'Diary(postId: $postId, date: $date, title: $title, description: $description, userId: $userId, updatedDate: $updatedDate)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$DiaryCopyWith<$Res> implements $DiaryCopyWith<$Res> {
+  factory _$DiaryCopyWith(_Diary value, $Res Function(_Diary) _then) = __$DiaryCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'post_id', includeToJson: false) String? postId, DateTime date, String title, String description,@JsonKey(name: 'user_id') String userId,@JsonKey(name: 'updated_date', includeToJson: false) DateTime? updatedDate
+});
+
+
+
+
+}
+/// @nodoc
+class __$DiaryCopyWithImpl<$Res>
+    implements _$DiaryCopyWith<$Res> {
+  __$DiaryCopyWithImpl(this._self, this._then);
+
+  final _Diary _self;
+  final $Res Function(_Diary) _then;
+
+/// Create a copy of Diary
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? postId = freezed,Object? date = null,Object? title = null,Object? description = null,Object? userId = null,Object? updatedDate = freezed,}) {
+  return _then(_Diary(
+postId: freezed == postId ? _self.postId : postId // ignore: cast_nullable_to_non_nullable
+as String?,date: null == date ? _self.date : date // ignore: cast_nullable_to_non_nullable
+as DateTime,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,description: null == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,updatedDate: freezed == updatedDate ? _self.updatedDate : updatedDate // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/diary/model/diary.g.dart
+++ b/lib/features/diary/model/diary.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'diary.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_Diary _$DiaryFromJson(Map<String, dynamic> json) => _Diary(
+  postId: json['post_id'] as String?,
+  date: DateTime.parse(json['date'] as String),
+  title: json['title'] as String,
+  description: json['description'] as String,
+  userId: json['user_id'] as String,
+  updatedDate: json['updated_date'] == null
+      ? null
+      : DateTime.parse(json['updated_date'] as String),
+);
+
+Map<String, dynamic> _$DiaryToJson(_Diary instance) => <String, dynamic>{
+  'date': instance.date.toIso8601String(),
+  'title': instance.title,
+  'description': instance.description,
+  'user_id': instance.userId,
+};

--- a/lib/features/diary/presentation/create_diary.dart
+++ b/lib/features/diary/presentation/create_diary.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import '../../auth/data/auth_providers.dart';
+import '../model/diary.dart';
+import '../repository/diary_providers.dart';
+
+class CreateDiary extends ConsumerStatefulWidget {
+  const CreateDiary({super.key});
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _CreateDiaryState();
+}
+
+class _CreateDiaryState extends ConsumerState<CreateDiary> {
+  final _formKey = GlobalKey<FormState>();
+  final _dateController = TextEditingController();
+  final _titleController = TextEditingController();
+  final _desController = TextEditingController();
+
+  // 日付変換フォーマット
+  final dateformat = DateFormat('yyyy/MM/dd');
+
+  // 内部日付情報
+  DateTime? _selectedDate;
+
+  @override
+  void initState() {
+    super.initState();
+    _setDate();
+  }
+
+  void _setDate() {
+    // 本日の日付を取得
+    final now = DateTime.now();
+    _selectedDate = now;
+    _dateController.text = dateformat.format(now);
+  }
+
+  Future<void> _selectDate(BuildContext context) async {
+    // 本日の日付を取得
+    final now = DateTime.now();
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: now,
+      firstDate: DateTime(2000),
+      lastDate: DateTime(2100),
+    );
+
+    if (picked != null) {
+      _selectedDate = picked;
+      setState(() {
+        _dateController.text = dateformat.format(picked);
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // ログイン中のユーザを取得
+    final currentUser = ref.watch(currentUserProvider);
+    // 日記のRepositoryを取得
+    final diaryRepository = ref.watch(diaryRepositoryProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: Text('日記作成')),
+      body: Center(
+        child: Card(
+          elevation: 4,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Padding(
+            padding: EdgeInsets.all(24),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '今日の日記を作成しましょう',
+                    style: Theme.of(context).textTheme.headlineSmall,
+                  ),
+                  SizedBox(height: 16),
+                  TextFormField(
+                    controller: _dateController,
+                    readOnly: true,
+                    decoration: InputDecoration(
+                      labelText: '日付',
+                      suffixIcon: IconButton(
+                        onPressed: () => _selectDate(context),
+                        icon: Icon(Icons.calendar_today),
+                      ),
+                    ),
+                    onTap: () => _selectDate(context),
+                  ),
+                  SizedBox(height: 8),
+                  TextFormField(
+                    controller: _titleController,
+                    keyboardType: TextInputType.text,
+                    decoration: InputDecoration(labelText: 'タイトル'),
+                  ),
+                  SizedBox(height: 8),
+                  TextFormField(
+                    controller: _desController,
+                    decoration: InputDecoration(labelText: '本文'),
+                  ),
+                  SizedBox(height: 24),
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: () async {
+                        final diary = Diary(
+                          date: _selectedDate!,
+                          title: _titleController.text,
+                          description: _desController.text,
+                          userId: currentUser!.id,
+                        );
+                        final response = await diaryRepository.insertDiary(
+                          diary,
+                        );
+
+                        print(response);
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text("日記投稿完了！"),
+                              duration: Duration(seconds: 2),
+                            ),
+                          );
+                        }
+                      },
+                      child: Text('投稿'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/diary/repository/diary_providers.dart
+++ b/lib/features/diary/repository/diary_providers.dart
@@ -1,0 +1,9 @@
+// 日記Repository
+import 'package:ai_analysis_diary_app/features/diary/repository/diary_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/provider/core_providers.dart';
+
+final diaryRepositoryProvider = Provider<DiaryRepository>((ref) {
+  return DiaryRepository(ref.watch(supabaseProvider));
+});

--- a/lib/features/diary/repository/diary_repository.dart
+++ b/lib/features/diary/repository/diary_repository.dart
@@ -1,0 +1,14 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../model/diary.dart';
+
+class DiaryRepository {
+  final SupabaseClient supabase;
+
+  DiaryRepository(this.supabase);
+
+  Future<Diary> insertDiary(Diary diary) async {
+    final response = await supabase.from('diary').insert(diary.toJson()).select().single();
+    return Diary.fromJson(response);
+  }
+}

--- a/lib/features/home/presentation/homepage.dart
+++ b/lib/features/home/presentation/homepage.dart
@@ -1,3 +1,4 @@
+import 'package:ai_analysis_diary_app/features/diary/presentation/create_diary.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -15,14 +16,21 @@ class HomePage extends ConsumerWidget {
         title: Text('ホーム'),
         actions: [
           IconButton(
-              onPressed: () => authRepo.signOut(), icon: Icon(Icons.logout))
+            onPressed: () => authRepo.signOut(),
+            icon: Icon(Icons.logout),
+          ),
         ],
       ),
-      body: Center(
-        child: Text('ログイン済み！')
+      body: Center(child: Text('ログイン済み！')),
+      floatingActionButton: IconButton(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (context) => CreateDiary()),
+          );
+        },
+        icon: Icon(Icons.create),
       ),
     );
   }
-
-
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  build:
+    dependency: transitive
+    description:
+      name: build
+      sha256: c1668065e9ba04752570ad7e038288559d1e2ca5c6d0131c0f5f55e39e777413
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.3"
+  build_config:
+    dependency: transitive
+    description:
+      name: build_config
+      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
+  build_daemon:
+    dependency: transitive
+    description:
+      name: build_daemon
+      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
+  build_runner:
+    dependency: "direct dev"
+    description:
+      name: build_runner
+      sha256: "110c56ef29b5eb367b4d17fc79375fa8c18a6cd7acd92c05bb3986c17a079057"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.4"
+  built_collection:
+    dependency: transitive
+    description:
+      name: built_collection
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.1"
+  built_value:
+    dependency: transitive
+    description:
+      name: built_value
+      sha256: "426cf75afdb23aa74bd4e471704de3f9393f3c7b04c1e2d9c6f1073ae0b8b139"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.12.1"
   characters:
     dependency: transitive
     description:
@@ -89,6 +137,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  checked_yaml:
+    dependency: transitive
+    description:
+      name: checked_yaml
+      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.4"
   cli_config:
     dependency: transitive
     description:
@@ -105,6 +161,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  code_builder:
+    dependency: transitive
+    description:
+      name: code_builder
+      sha256: "11654819532ba94c34de52ff5feb52bd81cba1de00ef2ed622fd50295f9d4243"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.11.0"
   collection:
     dependency: transitive
     description:
@@ -145,6 +209,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dart_style:
+    dependency: transitive
+    description:
+      name: dart_style
+      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
   fake_async:
     dependency: transitive
     description:
@@ -216,6 +288,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed:
+    dependency: "direct dev"
+    description:
+      name: freezed
+      sha256: "13065f10e135263a4f5a4391b79a8efc5fb8106f8dd555a9e49b750b45393d77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.3"
+  freezed_annotation:
+    dependency: "direct main"
+    description:
+      name: freezed_annotation
+      sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -256,6 +344,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.16.0"
+  graphs:
+    dependency: transitive
+    description:
+      name: graphs
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   gtk:
     dependency: transitive
     description:
@@ -296,6 +392,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
@@ -320,6 +424,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.2"
+  json_annotation:
+    dependency: "direct main"
+    description:
+      name: json_annotation
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.9.0"
+  json_serializable:
+    dependency: "direct dev"
+    description:
+      name: json_serializable
+      sha256: c5b2ee75210a0f263c6c7b9eeea80553dbae96ea1bf57f02484e806a3ffdffa3
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.11.2"
   jwt_decode:
     dependency: transitive
     description:
@@ -568,6 +688,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  pubspec_parse:
+    dependency: transitive
+    description:
+      name: pubspec_parse
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   realtime_client:
     dependency: transitive
     description:
@@ -717,6 +845,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  source_gen:
+    dependency: transitive
+    description:
+      name: source_gen
+      sha256: "07b277b67e0096c45196cbddddf2d8c6ffc49342e88bf31d460ce04605ddac75"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
+  source_helper:
+    dependency: transitive
+    description:
+      name: source_helper
+      sha256: "6a3c6cc82073a8797f8c4dc4572146114a39652851c157db37e964d9c7038723"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.8"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -773,6 +917,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,9 @@ dependencies:
   logger: ^2.6.2
   path_provider: ^2.1.5
   sentry_flutter: ^9.8.0
+  intl: ^0.20.2
+  freezed_annotation: ^3.1.0
+  json_annotation: ^4.9.0
 
 dev_dependencies:
   sentry_dart_plugin: ^3.2.0
@@ -53,6 +56,9 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^6.0.0
+  freezed: ^3.2.3
+  build_runner: ^2.10.4
+  json_serializable: ^6.11.2
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
### 変更内容
- 日記投稿画面（最低限）のUI作成
- SupabaseのDiaryテーブルに登録処理を実装

### 背景・目的
ユーザーが日記を投稿した際に、SupabaseのDBに登録できるようにする

### 動作確認
- Androidエミュレータで成功
- iOSは未確認
