### PR TITLE
20251228_Supabaseの日記をSupabaseEdgeFunctionでAIに分析させて、結果をDBに登録する処理を実装

### DIFF
--- a/lib/features/diary/presentation/create_diary.dart
+++ b/lib/features/diary/presentation/create_diary.dart
@@ -112,17 +112,19 @@ class _CreateDiaryState extends ConsumerState<CreateDiary> {
                     width: double.infinity,
                     child: ElevatedButton(
                       onPressed: () async {
+                        // 日記をDBに登録
                         final diary = Diary(
                           date: _selectedDate!,
                           title: _titleController.text,
                           description: _desController.text,
                           userId: currentUser!.id,
                         );
-                        final response = await diaryRepository.insertDiary(
-                          diary,
-                        );
+                        final response = await diaryRepository.insertDiary(diary);
 
-                        print(response);
+                        // 日記をAIに分析させる
+                        final res = await diaryRepository.analyzeDiary(response.userId, response.postId!);
+
+                        // 日記投稿完了
                         if (context.mounted) {
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
@@ -130,6 +132,7 @@ class _CreateDiaryState extends ConsumerState<CreateDiary> {
                               duration: Duration(seconds: 2),
                             ),
                           );
+                          Navigator.pop(context);
                         }
                       },
                       child: Text('投稿'),

--- a/lib/features/diary/repository/diary_repository.dart
+++ b/lib/features/diary/repository/diary_repository.dart
@@ -11,4 +11,9 @@ class DiaryRepository {
     final response = await supabase.from('diary').insert(diary.toJson()).select().single();
     return Diary.fromJson(response);
   }
+
+  Future<dynamic> analyzeDiary(String userId, String postId) async {
+    final response = await supabase.functions.invoke('analyze-diary', body: {'userId': userId, 'postId': postId});
+    return response.data;
+  }
 }


### PR DESCRIPTION
### 変更内容
- SupabaseEdgeFunctionsを使って、サーバー側で日記の内容をAIに分析させることに成功
- 分析結果をDBに保存

### 背景・目的
ユーザーが日記を投稿後、AIに分析させるため

### 動作確認
- Android実端末で成功

Close #3 