### PR TITLE
20251229_日記投稿画面の詳細を詰めた（二重タップの防止や、キーボードに被らないように設定するなど）

### DIFF
--- a/lib/core/utils/widget/keyboard_dismiss.dart
+++ b/lib/core/utils/widget/keyboard_dismiss.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/cupertino.dart';
+
+class KeyboardDismiss extends StatelessWidget {
+  final Widget child;
+
+  const KeyboardDismiss({
+    super.key,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () => FocusScope.of(context).unfocus(),
+      child: child,
+    );
+  }
+}

--- a/lib/features/auth/presentation/login_page.dart
+++ b/lib/features/auth/presentation/login_page.dart
@@ -15,15 +15,15 @@ class LoginPage extends ConsumerStatefulWidget {
 
 class _LoginPageState extends ConsumerState<LoginPage> {
   final _formKey = GlobalKey<FormState>();
-  final emailCtrl = TextEditingController();
-  final passCtrl = TextEditingController();
+  final _emailCtrl = TextEditingController();
+  final _passCtrl = TextEditingController();
 
-  bool isLoading = false;
+  bool _isLoading = false;
 
   @override
   void dispose() {
-    emailCtrl.dispose();
-    passCtrl.dispose();
+    _emailCtrl.dispose();
+    _passCtrl.dispose();
     super.dispose();
   }
 
@@ -63,7 +63,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
 
                           /// メールアドレス入力
                           TextFormField(
-                            controller: emailCtrl,
+                            controller: _emailCtrl,
                             keyboardType: TextInputType.emailAddress,
                             decoration: InputDecoration(
                               labelText: 'メールアドレス',
@@ -84,7 +84,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
 
                           /// パスワード入力
                           TextFormField(
-                            controller: passCtrl,
+                            controller: _passCtrl,
                             decoration: InputDecoration(
                               labelText: 'パスワード',
                               prefixIcon: Icon(Icons.lock),
@@ -106,7 +106,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                           SizedBox(
                             width: double.infinity,
                             child: ElevatedButton(
-                              onPressed: isLoading
+                              onPressed: _isLoading
                                   ? null
                                   : () async {
                                       // ヴァリデーションが失敗しているなら何もしない
@@ -115,13 +115,13 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                                       }
                                       // ローディング中のフラグ更新
                                       setState(() {
-                                        isLoading = true;
+                                        _isLoading = true;
                                       });
 
                                       try {
                                         await authRepo.signIn(
-                                          emailCtrl.text,
-                                          passCtrl.text,
+                                          _emailCtrl.text,
+                                          _passCtrl.text,
                                         );
                                       } catch (e, st) {
                                         // ログにエラーの詳細を残す
@@ -143,11 +143,11 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                                         );
                                       } finally {
                                         setState(() {
-                                          isLoading = false;
+                                          _isLoading = false;
                                         });
                                       }
                                     },
-                              child: isLoading
+                              child: _isLoading
                                   ? SizedBox(
                                       height: 20,
                                       width: 20,

--- a/lib/features/diary/presentation/create_diary.dart
+++ b/lib/features/diary/presentation/create_diary.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
+import '../../../core/utils/widget/keyboard_dismiss.dart';
 import '../../auth/data/auth_providers.dart';
 import '../model/diary.dart';
 import '../repository/diary_providers.dart';
@@ -18,6 +19,11 @@ class _CreateDiaryState extends ConsumerState<CreateDiary> {
   final _dateController = TextEditingController();
   final _titleController = TextEditingController();
   final _desController = TextEditingController();
+  final _titleFocus = FocusNode();
+  final _desFocus = FocusNode();
+
+  // 読み込み中
+  bool _isLoading = false;
 
   // 日付変換フォーマット
   final dateformat = DateFormat('yyyy/MM/dd');
@@ -29,6 +35,16 @@ class _CreateDiaryState extends ConsumerState<CreateDiary> {
   void initState() {
     super.initState();
     _setDate();
+  }
+
+  @override
+  void dispose() {
+    _dateController.dispose();
+    _titleController.dispose();
+    _desController.dispose();
+    _titleFocus.dispose();
+    _desFocus.dispose();
+    super.dispose();
   }
 
   void _setDate() {
@@ -65,85 +81,178 @@ class _CreateDiaryState extends ConsumerState<CreateDiary> {
 
     return Scaffold(
       appBar: AppBar(title: Text('日記作成')),
-      body: Center(
-        child: Card(
-          elevation: 4,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
+      body: KeyboardDismiss(
+        child: SingleChildScrollView(
+          padding: EdgeInsets.only(
+            left: 16,
+            right: 16,
+            top: 16,
+            bottom: MediaQuery.of(context).viewInsets.bottom + 16,
           ),
-          child: Padding(
-            padding: EdgeInsets.all(24),
-            child: Form(
-              key: _formKey,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    '今日の日記を作成しましょう',
-                    style: Theme.of(context).textTheme.headlineSmall,
-                  ),
-                  SizedBox(height: 16),
-                  TextFormField(
-                    controller: _dateController,
-                    readOnly: true,
-                    decoration: InputDecoration(
-                      labelText: '日付',
-                      suffixIcon: IconButton(
-                        onPressed: () => _selectDate(context),
-                        icon: Icon(Icons.calendar_today),
+          child: Card(
+            elevation: 4,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: Padding(
+              padding: EdgeInsets.all(24),
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '日記を作成しましょう',
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ),
+                    SizedBox(height: 16),
+                    TextFormField(
+                      controller: _dateController,
+                      readOnly: true,
+                      decoration: InputDecoration(
+                        labelText: '日付',
+                        suffixIcon: IconButton(
+                          onPressed: () => _selectDate(context),
+                          icon: Icon(Icons.calendar_today),
+                        ),
+                      ),
+                      onTap: () => _selectDate(context),
+                    ),
+                    SizedBox(height: 8),
+                    TextFormField(
+                      controller: _titleController,
+                      focusNode: _titleFocus,
+                      onTap: () => _scrollToField(_titleFocus),
+                      keyboardType: TextInputType.text,
+                      maxLength: 20,
+                      decoration: InputDecoration(labelText: 'タイトル'),
+                      validator: (value) {
+                        if (value == null || value.isEmpty) {
+                          return 'タイトルを入力してください';
+                        }
+                        if (value.length > 20) {
+                          return 'タイトルは20文字以内で入力してください';
+                        }
+                        return null;
+                      },
+                    ),
+                    SizedBox(height: 8),
+                    SizedBox(
+                      height: 240,
+                      child: TextFormField(
+                        controller: _desController,
+                        focusNode: _desFocus,
+                        onTap: () => _scrollToField(_desFocus),
+                        expands: true,
+                        maxLines: null,
+                        maxLength: 2000,
+                        keyboardType: TextInputType.multiline,
+                        textAlignVertical: TextAlignVertical.top,
+                        decoration: InputDecoration(
+                          labelText: '本文',
+                          hintText: '今日あったことを自由に書いてください',
+                          alignLabelWithHint: true,
+                          border: OutlineInputBorder(),
+                          contentPadding: EdgeInsets.all(12),
+                        ),
+                        validator: (value) {
+                          if (value == null || value.isEmpty) {
+                            return '本文を入力してください';
+                          }
+                          if (value.length > 2000) {
+                            return '本文は2000文字以内で入力してください';
+                          }
+                          return null;
+                        },
                       ),
                     ),
-                    onTap: () => _selectDate(context),
-                  ),
-                  SizedBox(height: 8),
-                  TextFormField(
-                    controller: _titleController,
-                    keyboardType: TextInputType.text,
-                    decoration: InputDecoration(labelText: 'タイトル'),
-                  ),
-                  SizedBox(height: 8),
-                  TextFormField(
-                    controller: _desController,
-                    decoration: InputDecoration(labelText: '本文'),
-                  ),
-                  SizedBox(height: 24),
-                  SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton(
-                      onPressed: () async {
-                        // 日記をDBに登録
-                        final diary = Diary(
-                          date: _selectedDate!,
-                          title: _titleController.text,
-                          description: _desController.text,
-                          userId: currentUser!.id,
-                        );
-                        final response = await diaryRepository.insertDiary(diary);
+                    SizedBox(height: 24),
+                    SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton(
+                        onPressed: _isLoading
+                            ? null
+                            : () async {
+                                // ヴァリデーションが失敗しているなら何もしない
+                                if (!_formKey.currentState!.validate()) {
+                                  return;
+                                }
+                                // 読み込み中
+                                setState(() {
+                                  _isLoading = true;
+                                });
 
-                        // 日記をAIに分析させる
-                        final res = await diaryRepository.analyzeDiary(response.userId, response.postId!);
+                                try {
+                                  // 日記をDBに登録
+                                  final diary = Diary(
+                                    date: _selectedDate!,
+                                    title: _titleController.text,
+                                    description: _desController.text,
+                                    userId: currentUser!.id,
+                                  );
+                                  final response = await diaryRepository
+                                      .insertDiary(diary);
 
-                        // 日記投稿完了
-                        if (context.mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(
-                              content: Text("日記投稿完了！"),
-                              duration: Duration(seconds: 2),
-                            ),
-                          );
-                          Navigator.pop(context);
-                        }
-                      },
-                      child: Text('投稿'),
+                                  // 日記をAIに分析させる
+                                  final res = await diaryRepository
+                                      .analyzeDiary(
+                                        response.userId,
+                                        response.postId!,
+                                      );
+
+                                  // 日記投稿完了
+                                  if (context.mounted) {
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      SnackBar(
+                                        content: Text("日記投稿完了！"),
+                                        duration: Duration(seconds: 2),
+                                      ),
+                                    );
+                                    Navigator.pop(context);
+                                  }
+                                } catch (e) {
+                                  if (context.mounted) {
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      SnackBar(content: Text('投稿に失敗しました')),
+                                    );
+                                  }
+                                } finally {
+                                  setState(() {
+                                    _isLoading = false;
+                                  });
+                                }
+                              },
+                        child: _isLoading
+                            ? SizedBox(
+                                height: 20,
+                                width: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : Text('投稿'),
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),
         ),
       ),
     );
+  }
+
+  void _scrollToField(FocusNode node) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!node.hasFocus) return;
+
+      Scrollable.ensureVisible(
+        node.context!,
+        duration: const Duration(milliseconds: 250),
+        curve: Curves.easeInOut,
+        alignment: 0.2, // 上寄せ
+      );
+    });
   }
 }


### PR DESCRIPTION
### 変更内容
- 日記作成画面のUIを詰めた
- 二重タップ防止
- キーボードで被らないように修正

### 背景・目的
ユーザーが快適に日記を投稿できるように

### 動作確認
- Android実端末で確認
- iOSは未確認
