### PR TITLE
20260113_共通ローディング画面実装

### DIFF
--- a/lib/core/utils/widget/app_loading_overlay.dart
+++ b/lib/core/utils/widget/app_loading_overlay.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+
+// ルートではなく、各画面のScaffoldの上に設定する
+final loadingProvider = StateProvider<bool>((ref) => false);
+
+class AppLoadingOverlay extends ConsumerWidget {
+  final Widget child;
+
+  const AppLoadingOverlay({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isLoading = ref.watch(loadingProvider);
+
+    return Stack(
+      children: [
+        child,
+        if (isLoading)
+          AbsorbPointer(
+            child: Container(
+              color: Colors.black.withValues(alpha: 0.5),
+              child: const Center(child: CircularProgressIndicator()),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/features/auth/presentation/auth_page.dart
+++ b/lib/features/auth/presentation/auth_page.dart
@@ -3,10 +3,9 @@ import 'package:ai_analysis_diary_app/features/auth/presentation/widgets/auth_fo
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-enum AuthMode {
-  login,
-  signup,
-}
+import '../../../core/utils/widget/app_loading_overlay.dart';
+
+enum AuthMode { login, signup }
 
 class AuthPage extends ConsumerWidget {
   final AuthMode mode;
@@ -18,38 +17,40 @@ class AuthPage extends ConsumerWidget {
     final state = ref.watch(authViewModelProvider(mode));
     final notifier = ref.read(authViewModelProvider(mode).notifier);
 
-    return Scaffold(
-      appBar: AppBar(title: Text(mode == AuthMode.login ? 'ログイン' : 'サインアップ')),
-      body: LayoutBuilder(
-        builder: (context, constraints) {
-          return SingleChildScrollView(
-            padding: EdgeInsets.all(16),
-            child: ConstrainedBox(
-              constraints: BoxConstraints(
-                minHeight: constraints.maxHeight * 0.8,
-              ),
-              child: Center(
-                child: Card(
-                  elevation: 4,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(16),
-                  ),
-                  child: Padding(
-                    padding: EdgeInsets.all(24),
-                    child: AuthForm(
-                      mode: mode,
-                      state: state,
-                      onEmailChanged: notifier.onEmailChanged,
-                      onPasswordChanged: notifier.onPasswordChanged,
-                      onSubmit: notifier.submit,
-                      onSwitchModeTap: notifier.onSwitchModeTap,
-                    )
+    return AppLoadingOverlay(
+      child: Scaffold(
+        appBar: AppBar(title: Text(mode == AuthMode.login ? 'ログイン' : 'サインアップ')),
+        body: LayoutBuilder(
+          builder: (context, constraints) {
+            return SingleChildScrollView(
+              padding: EdgeInsets.all(16),
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  minHeight: constraints.maxHeight * 0.8,
+                ),
+                child: Center(
+                  child: Card(
+                    elevation: 4,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                    child: Padding(
+                      padding: EdgeInsets.all(24),
+                      child: AuthForm(
+                        mode: mode,
+                        state: state,
+                        onEmailChanged: notifier.onEmailChanged,
+                        onPasswordChanged: notifier.onPasswordChanged,
+                        onSubmit: notifier.submit,
+                        onSwitchModeTap: notifier.onSwitchModeTap,
+                      ),
+                    ),
                   ),
                 ),
               ),
-            ),
-          );
-        },
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/features/auth/presentation/view_model/auth_state.dart
+++ b/lib/features/auth/presentation/view_model/auth_state.dart
@@ -3,9 +3,6 @@ class AuthState {
   final String email;
   final String password;
 
-  // 読み込み中
-  final bool isLoading;
-
   // エラーメッセージ
   final String? emailError;
   final String? passwordError;
@@ -14,7 +11,6 @@ class AuthState {
   const AuthState({
     this.email = '',
     this.password = '',
-    this.isLoading = false,
     this.emailError,
     this.passwordError,
     this.errorMessage,
@@ -30,7 +26,6 @@ class AuthState {
   AuthState copyWith({
     String? email,
     String? password,
-    bool? isLoading,
     String? emailError,
     String? passwordError,
     String? errorMessage,
@@ -38,7 +33,6 @@ class AuthState {
     return AuthState(
       email: email ?? this.email,
       password: password ?? this.password,
-      isLoading: isLoading ?? this.isLoading,
       emailError: emailError,
       passwordError: passwordError,
       errorMessage: errorMessage,

--- a/lib/features/auth/presentation/view_model/auth_view_model.dart
+++ b/lib/features/auth/presentation/view_model/auth_view_model.dart
@@ -3,8 +3,10 @@ import 'dart:async';
 import 'package:ai_analysis_diary_app/features/auth/domain/validate_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 
 import '../../../../core/utils/dialog_service.dart';
+import '../../../../core/utils/widget/app_loading_overlay.dart';
 import '../../repository/auth_providers.dart';
 import '../auth_page.dart';
 import 'auth_state.dart';
@@ -22,6 +24,11 @@ class AuthViewModel extends AsyncNotifier<AuthState> {
 
   // 共通DialogService取得
   late final _dialogService = ref.read(dialogServiceProvider);
+
+  // ローディング状態管理
+  late final StateController<bool> _loadingController = ref.read(
+    loadingProvider.notifier,
+  );
 
   @override
   Future<AuthState> build() async {
@@ -51,12 +58,15 @@ class AuthViewModel extends AsyncNotifier<AuthState> {
   // ====== 送信処理 ======
   Future<void> submit() async {
     final current = state.requireValue;
+
     // バリデーションNG or ローディング中
-    if (!current.isValid || current.isLoading) {
+    if (!current.isValid || state.isLoading) {
       return;
     }
-    state = AsyncData(current.copyWith(isLoading: true));
 
+    // ローディング中
+    _loadingController.state = true;
+    state = const AsyncLoading();
     try {
       if (_mode == AuthMode.login) {
         // ログイン
@@ -70,7 +80,8 @@ class AuthViewModel extends AsyncNotifier<AuthState> {
     } catch (e) {
       state = AsyncData(current.copyWith(errorMessage: e.toString()));
     } finally {
-      state = AsyncData(current.copyWith(isLoading: false));
+      // ローディング解除
+      _loadingController.state = false;
     }
   }
 

--- a/lib/features/auth/presentation/widgets/auth_form.dart
+++ b/lib/features/auth/presentation/widgets/auth_form.dart
@@ -105,14 +105,8 @@ class _AuthFormState extends ConsumerState<AuthForm> {
               SizedBox(
                 width: double.infinity,
                 child: ElevatedButton(
-                  onPressed: widget.state.isLoading ? null : widget.onSubmit,
-                  child: widget.state.isLoading
-                      ? SizedBox(
-                          height: 20,
-                          width: 20,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : widget.mode == AuthMode.login
+                  onPressed: widget.onSubmit,
+                  child: widget.mode == AuthMode.login
                       ? Text('ログイン')
                       : Text('サインアップ'),
                 ),

--- a/lib/features/diary/presentation/create_diary.dart
+++ b/lib/features/diary/presentation/create_diary.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:intl/intl.dart';
 
+import '../../../core/utils/widget/app_loading_overlay.dart';
 import '../../../core/utils/widget/keyboard_dismiss.dart';
 import '../../auth/repository/auth_providers.dart';
 import '../model/diary.dart';
@@ -78,167 +80,175 @@ class _CreateDiaryState extends ConsumerState<CreateDiary> {
     final currentUser = ref.watch(currentUserProvider);
     // 日記のRepositoryを取得
     final diaryRepository = ref.watch(diaryRepositoryProvider);
+    // ローディング状態管理
+    late final StateController<bool> loadingController = ref.read(
+      loadingProvider.notifier,
+    );
 
-    return Scaffold(
-      appBar: AppBar(title: Text('日記作成')),
-      body: KeyboardDismiss(
-        child: SingleChildScrollView(
-          padding: EdgeInsets.only(
-            left: 16,
-            right: 16,
-            top: 16,
-            bottom: MediaQuery.of(context).viewInsets.bottom + 16,
-          ),
-          child: Card(
-            elevation: 4,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(16),
+    return AppLoadingOverlay(
+      child: Scaffold(
+        appBar: AppBar(title: Text('日記作成')),
+        body: KeyboardDismiss(
+          child: SingleChildScrollView(
+            padding: EdgeInsets.only(
+              left: 16,
+              right: 16,
+              top: 16,
+              bottom: MediaQuery.of(context).viewInsets.bottom + 16,
             ),
-            child: Padding(
-              padding: EdgeInsets.all(24),
-              child: Form(
-                key: _formKey,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      '日記を作成しましょう',
-                      style: Theme.of(context).textTheme.headlineSmall,
-                    ),
-                    SizedBox(height: 16),
-                    TextFormField(
-                      controller: _dateController,
-                      readOnly: true,
-                      decoration: InputDecoration(
-                        labelText: '日付',
-                        suffixIcon: IconButton(
-                          onPressed: () => _selectDate(context),
-                          icon: Icon(Icons.calendar_today),
-                        ),
+            child: Card(
+              elevation: 4,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: Padding(
+                padding: EdgeInsets.all(24),
+                child: Form(
+                  key: _formKey,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '日記を作成しましょう',
+                        style: Theme.of(context).textTheme.headlineSmall,
                       ),
-                      onTap: () => _selectDate(context),
-                    ),
-                    SizedBox(height: 8),
-                    TextFormField(
-                      controller: _titleController,
-                      focusNode: _titleFocus,
-                      onTap: () => _scrollToField(_titleFocus),
-                      keyboardType: TextInputType.text,
-                      maxLength: 20,
-                      decoration: InputDecoration(labelText: 'タイトル'),
-                      validator: (value) {
-                        if (value == null || value.isEmpty) {
-                          return 'タイトルを入力してください';
-                        }
-                        if (value.length > 20) {
-                          return 'タイトルは20文字以内で入力してください';
-                        }
-                        return null;
-                      },
-                    ),
-                    SizedBox(height: 8),
-                    SizedBox(
-                      height: 240,
-                      child: TextFormField(
-                        controller: _desController,
-                        focusNode: _desFocus,
-                        onTap: () => _scrollToField(_desFocus),
-                        expands: true,
-                        maxLines: null,
-                        maxLength: 2000,
-                        keyboardType: TextInputType.multiline,
-                        textAlignVertical: TextAlignVertical.top,
+                      SizedBox(height: 16),
+                      TextFormField(
+                        controller: _dateController,
+                        readOnly: true,
                         decoration: InputDecoration(
-                          labelText: '本文',
-                          hintText: '今日あったことを自由に書いてください',
-                          alignLabelWithHint: true,
-                          border: OutlineInputBorder(),
-                          contentPadding: EdgeInsets.all(12),
+                          labelText: '日付',
+                          suffixIcon: IconButton(
+                            onPressed: () => _selectDate(context),
+                            icon: Icon(Icons.calendar_today),
+                          ),
                         ),
+                        onTap: () => _selectDate(context),
+                      ),
+                      SizedBox(height: 8),
+                      TextFormField(
+                        controller: _titleController,
+                        focusNode: _titleFocus,
+                        onTap: () => _scrollToField(_titleFocus),
+                        keyboardType: TextInputType.text,
+                        maxLength: 20,
+                        decoration: InputDecoration(labelText: 'タイトル'),
                         validator: (value) {
                           if (value == null || value.isEmpty) {
-                            return '本文を入力してください';
+                            return 'タイトルを入力してください';
                           }
-                          if (value.length > 2000) {
-                            return '本文は2000文字以内で入力してください';
+                          if (value.length > 20) {
+                            return 'タイトルは20文字以内で入力してください';
                           }
                           return null;
                         },
                       ),
-                    ),
-                    SizedBox(height: 24),
-                    SizedBox(
-                      width: double.infinity,
-                      child: ElevatedButton(
-                        onPressed: _isLoading
-                            ? null
-                            : () async {
-                                // ヴァリデーションが失敗しているなら何もしない
-                                if (!_formKey.currentState!.validate()) {
-                                  return;
-                                }
-                                // 読み込み中
-                                setState(() {
-                                  _isLoading = true;
-                                });
-
-                                try {
-                                  // 日記をDBに登録
-                                  final diary = Diary(
-                                    date: _selectedDate!,
-                                    title: _titleController.text,
-                                    description: _desController.text,
-                                    userId: currentUser!.id,
-                                  );
-                                  final response = await diaryRepository
-                                      .insertDiary(diary);
-
-                                  // 日記をAIに分析させる
-                                  await diaryRepository.analyzeDiary(
-                                    response.userId,
-                                    response.postId!,
-                                  );
-
-                                  // 感情に応じたアドバイスを生成
-                                  await diaryRepository.generateAdvice(
-                                    response.userId,
-                                    response.postId!,
-                                  );
-
-                                  // 日記投稿完了
-                                  if (context.mounted) {
-                                    ScaffoldMessenger.of(context).showSnackBar(
-                                      SnackBar(
-                                        content: Text("日記投稿完了！"),
-                                        duration: Duration(seconds: 2),
-                                      ),
-                                    );
-                                    Navigator.pop(context);
-                                  }
-                                } catch (e) {
-                                  if (context.mounted) {
-                                    ScaffoldMessenger.of(context).showSnackBar(
-                                      SnackBar(content: Text('投稿に失敗しました')),
-                                    );
-                                  }
-                                } finally {
-                                  setState(() {
-                                    _isLoading = false;
-                                  });
-                                }
-                              },
-                        child: _isLoading
-                            ? SizedBox(
-                                height: 20,
-                                width: 20,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                ),
-                              )
-                            : Text('投稿'),
+                      SizedBox(height: 8),
+                      SizedBox(
+                        height: 240,
+                        child: TextFormField(
+                          controller: _desController,
+                          focusNode: _desFocus,
+                          onTap: () => _scrollToField(_desFocus),
+                          expands: true,
+                          maxLines: null,
+                          maxLength: 2000,
+                          keyboardType: TextInputType.multiline,
+                          textAlignVertical: TextAlignVertical.top,
+                          decoration: InputDecoration(
+                            labelText: '本文',
+                            hintText: '今日あったことを自由に書いてください',
+                            alignLabelWithHint: true,
+                            border: OutlineInputBorder(),
+                            contentPadding: EdgeInsets.all(12),
+                          ),
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return '本文を入力してください';
+                            }
+                            if (value.length > 2000) {
+                              return '本文は2000文字以内で入力してください';
+                            }
+                            return null;
+                          },
+                        ),
                       ),
-                    ),
-                  ],
+                      SizedBox(height: 24),
+                      SizedBox(
+                        width: double.infinity,
+                        child: ElevatedButton(
+                          onPressed: _isLoading
+                              ? null
+                              : () async {
+                                  // ヴァリデーションが失敗しているなら何もしない
+                                  if (!_formKey.currentState!.validate()) {
+                                    return;
+                                  }
+                                  // 読み込み中
+                                  setState(() {
+                                    _isLoading = true;
+                                  });
+                                  loadingController.state = true;
+      
+                                  try {
+                                    // 日記をDBに登録
+                                    final diary = Diary(
+                                      date: _selectedDate!,
+                                      title: _titleController.text,
+                                      description: _desController.text,
+                                      userId: currentUser!.id,
+                                    );
+                                    final response = await diaryRepository
+                                        .insertDiary(diary);
+      
+                                    // 日記をAIに分析させる
+                                    await diaryRepository.analyzeDiary(
+                                      response.userId,
+                                      response.postId!,
+                                    );
+      
+                                    // 感情に応じたアドバイスを生成
+                                    await diaryRepository.generateAdvice(
+                                      response.userId,
+                                      response.postId!,
+                                    );
+      
+                                    // 日記投稿完了
+                                    if (context.mounted) {
+                                      ScaffoldMessenger.of(context).showSnackBar(
+                                        SnackBar(
+                                          content: Text("日記投稿完了！"),
+                                          duration: Duration(seconds: 2),
+                                        ),
+                                      );
+                                      Navigator.pop(context);
+                                    }
+                                  } catch (e) {
+                                    if (context.mounted) {
+                                      ScaffoldMessenger.of(context).showSnackBar(
+                                        SnackBar(content: Text('投稿に失敗しました')),
+                                      );
+                                    }
+                                  } finally {
+                                    setState(() {
+                                      _isLoading = false;
+                                    });
+                                    loadingController.state = false;
+                                  }
+                                },
+                          child: _isLoading
+                              ? SizedBox(
+                                  height: 20,
+                                  width: 20,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                  ),
+                                )
+                              : Text('投稿'),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
### 変更内容
- 時間が掛かる処理、現状はログイン、サインアップ時と日記投稿時にオーバーレイのローディング画面が表示するように修正

### 背景・目的
共通のローディング画面を実装し、どの画面でもローディングをオーバーレイで呼び出せるようにした

### 動作確認
- Android実端末で成功
- iOSは未確認

### 残課題
- [x] 日記投稿画面でボタンのローディングと、画面のローディングが重なっている
　→ 日記投稿画面のViewModel化で対応
- [x] AuthViewModelのAsyncValueのLoadingとローディングのProviderのstateの二重管理になっている
　→ 後でIssuesとして作成する